### PR TITLE
😶‍🌫️disable caching

### DIFF
--- a/tekton/execute-doc-ingestion-task.yaml
+++ b/tekton/execute-doc-ingestion-task.yaml
@@ -57,7 +57,7 @@ spec:
           doc_ingestion_pipeline,
           experiment_name="$(params.APPLICATION_NAME)-doc-ingestion", 
           namespace=namespace,
-          enable_caching=True
+          enable_caching=False
       )
 
       # save run id to query the logs


### PR DESCRIPTION
The Tekton pipeline was triggered after the PR merge to main, but the KFP pipeline didn't start because there was no change in the KFP pipeline definition compared to the previous run. It is better to disable caching so it can run when there is a change in only the collections as well.