### PR TITLE
Add last versions of products under AppDev space

### DIFF
--- a/collections/migration_toolkit_for_applications.json
+++ b/collections/migration_toolkit_for_applications.json
@@ -4,6 +4,26 @@
   "common_sources": [],
   "versions": [
     {
+      "version_number": "8.0",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "7.3",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
       "version_number": "7.2",
       "store_directive": "create_or_keep",
       "sources": [

--- a/collections/red_hat_advanced_developer_suite.json
+++ b/collections/red_hat_advanced_developer_suite.json
@@ -1,5 +1,5 @@
 {
-  "collection_base_name": "red_hat_advanced_developer_suite",
+  "collection_base_name": "red_hat_advanced_developer_suite_-_software_supply_chain",
   "collection_full_name": "Red Hat Advanced Developer Suite",
   "common_sources": [],
   "versions": [

--- a/collections/red_hat_advanced_developer_suite.json
+++ b/collections/red_hat_advanced_developer_suite.json
@@ -1,0 +1,27 @@
+{
+  "collection_base_name": "red_hat_advanced_developer_suite",
+  "collection_full_name": "Red Hat Advanced Developer Suite",
+  "common_sources": [],
+  "versions": [
+    {
+      "version_number": "1.7",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "1.6",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    }
+  ]
+}

--- a/collections/red_hat_amq_broker.json
+++ b/collections/red_hat_amq_broker.json
@@ -4,6 +4,16 @@
   "common_sources": [],
   "versions": [
     {
+      "version_number": "7.13",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
       "version_number": "7.12",
       "store_directive": "create_or_keep",
       "sources": [

--- a/collections/red_hat_connectivity_link.json
+++ b/collections/red_hat_connectivity_link.json
@@ -4,6 +4,26 @@
   "common_sources": [],
   "versions": [
     {
+      "version_number": "1.2",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "1.1",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
       "version_number": "1.0",
       "store_directive": "create_or_keep",
       "sources": [

--- a/collections/red_hat_openshift_dev_spaces.json
+++ b/collections/red_hat_openshift_dev_spaces.json
@@ -4,6 +4,56 @@
   "common_sources": [],
   "versions": [
     {
+      "version_number": "3.24",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },    
+    {
+      "version_number": "3.23",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },    
+    {
+      "version_number": "3.22",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },    
+    {
+      "version_number": "3.21",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },    
+    {
+      "version_number": "3.20",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
       "version_number": "3.18",
       "store_directive": "create_or_keep",
       "sources": [

--- a/collections/red_hat_openshift_gitops.json
+++ b/collections/red_hat_openshift_gitops.json
@@ -4,6 +4,36 @@
   "common_sources": [],
   "versions": [
     {
+      "version_number": "1.18",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "1.17",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "1.16",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
       "version_number": "1.15",
       "store_directive": "create_or_keep",
       "sources": [

--- a/collections/red_hat_openshift_pipelines.json
+++ b/collections/red_hat_openshift_pipelines.json
@@ -4,6 +4,36 @@
   "common_sources": [],
   "versions": [
     {
+      "version_number": "1.20",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "1.19",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "1.18",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
       "version_number": "1.17",
       "store_directive": "create_or_keep",
       "sources": [

--- a/collections/red_hat_openshift_serverless.json
+++ b/collections/red_hat_openshift_serverless.json
@@ -4,6 +4,16 @@
   "common_sources": [],
   "versions": [
     {
+      "version_number": "1.36",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
       "version_number": "1.35",
       "store_directive": "create_or_keep",
       "sources": [

--- a/collections/red_hat_openshift_service_mesh.json
+++ b/collections/red_hat_openshift_service_mesh.json
@@ -4,6 +4,26 @@
   "common_sources": [],
   "versions": [
     {
+      "version_number": "3.2",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "3.1",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
       "version_number": "3.0.0tp1",
       "store_directive": "create_or_keep",
       "sources": [

--- a/collections/red_hat_trusted_application_pipeline.json
+++ b/collections/red_hat_trusted_application_pipeline.json
@@ -4,6 +4,16 @@
   "common_sources": [],
   "versions": [
     {
+      "version_number": "1.5",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
       "version_number": "1.4",
       "store_directive": "create_or_keep",
       "sources": [

--- a/collections/red_hat_trusted_artifact_signer.json
+++ b/collections/red_hat_trusted_artifact_signer.json
@@ -4,6 +4,46 @@
   "common_sources": [],
   "versions": [
     {
+      "version_number": "1.3",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "1.2",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "1.1",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "1.0",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
       "version_number": "1",
       "store_directive": "create_or_keep",
       "sources": [

--- a/collections/red_hat_trusted_profile_analyzer.json
+++ b/collections/red_hat_trusted_profile_analyzer.json
@@ -4,6 +4,36 @@
   "common_sources": [],
   "versions": [
     {
+      "version_number": "2.1",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "2.0",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "1.3",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
       "version_number": "1.2",
       "store_directive": "create_or_keep",
       "sources": [

--- a/collections/streams_for_apache_kafka.json
+++ b/collections/streams_for_apache_kafka.json
@@ -4,6 +4,26 @@
   "common_sources": [],
   "versions": [
     {
+      "version_number": "3.0",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
+      "version_number": "2.9",
+      "store_directive": "create_or_keep",
+      "sources": [
+        {
+          "ingestion_type": "redhat_doc",
+          "language": "en-US"
+        }
+      ]
+    },
+    {
       "version_number": "2.8",
       "store_directive": "create_or_keep",
       "sources": [


### PR DESCRIPTION
This PR includes a set of updates in different collections to add the lastest stable versions of each product inside of the AppDev space.

The following collections are updated:

* Migration Toolkit for Applications
* Red Hat OpenShift Dev Spaces
* Red Hat Trusted profile Analyzer
* Red Hat Trusted Artifact Signer
* Red Hat Trusted Application Pipeline
* Red Hat OpenShift GitOps
* Red Hat OpenShift Pipelines
* Red Hat OpenShift Serverless
* Red Hat OpenShift Service Mesh 3
* Red Hat Connectivity Link
* Red Hat Streams for Apache Kafka
* Red Hat AMQ Broker

The following collection was added:

* Red Hat Advanced Developer Suite - it is the new name for Red Hat Truested Application Pipeline
